### PR TITLE
Fix handling directory error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build/
 composer.lock
 vendor/
+.phpunit.result.cache

--- a/src/StaticFileMiddleware.php
+++ b/src/StaticFileMiddleware.php
@@ -1030,7 +1030,7 @@ final class StaticFileMiddleware implements MiddlewareInterface
     {
         $filename = $this->publicDirectory.$request->getRequestTarget();
 
-        if (!is_readable($filename)) {
+        if (!is_readable($filename) || is_dir($filename)) {
             return $handler->handle($request);
         }
 

--- a/tests/Unit/StaticFileMiddlewareTest.php
+++ b/tests/Unit/StaticFileMiddlewareTest.php
@@ -234,6 +234,35 @@ final class StaticFileMiddlewareTest extends TestCase
         self::assertSame($response, $middleware->process($request, $handler));
     }
 
+    public function testBaseDirectory()
+    {
+        $publicDirectory = sys_get_temp_dir();
+        $requestTarget = '/';
+
+        /** @var ServerRequestInterface|MockObject $request */
+        $request = $this->getMockByCalls(ServerRequestInterface::class, [
+            Call::create('getRequestTarget')->with()->willReturn($requestTarget),
+        ]);
+
+        /** @var ResponseInterface|MockObject $response */
+        $response = $this->getMockByCalls(ResponseInterface::class);
+
+        /** @var RequestHandlerInterface|MockObject $handler */
+        $handler = $this->getMockByCalls(RequestHandlerInterface::class, [
+            Call::create('handle')->with($request)->willReturn($response),
+        ]);
+
+        /** @var ResponseFactoryInterface|MockObject $responseFactory */
+        $responseFactory = $this->getMockByCalls(ResponseFactoryInterface::class);
+
+        /** @var StreamFactoryInterface|MockObject $streamFactory */
+        $streamFactory = $this->getMockByCalls(StreamFactoryInterface::class);
+
+        $middleware = new StaticFileMiddleware($responseFactory, $streamFactory, $publicDirectory);
+
+        self::assertSame($response, $middleware->process($request, $handler));
+    }
+
     public function provideFiles(): array
     {
         return [


### PR DESCRIPTION
This PR fixes the error when the middleware tries to serve a directory, I saw this behavior only when the base url `/` is requested, for some reason `is_readable('/')` will return true and throws `hash_file(): read of 8192 bytes failed with errno=21 Is a directory` when `hash_file` is invoked.

![Screen Shot 2021-08-24 at 10 23 38](https://user-images.githubusercontent.com/109013/130592708-e1f7206a-9d46-4e28-8048-c17296079161.png)
